### PR TITLE
[SGP-24140] Make tasks Celery 5 compatible

### DIFF
--- a/rest_hooks/tasks.py
+++ b/rest_hooks/tasks.py
@@ -1,33 +1,49 @@
 import requests
 import json
 
-from celery.task import Task
-
 from django.core.serializers.json import DjangoJSONEncoder
 
 from rest_hooks.utils import get_hook_model
 
+def _do_hook(target, payload, instance=None, hook_id=None, **kwargs):
+    """
+    target:     the url to receive the payload.
+    payload:    a python primitive data structure
+    instance:   a possibly null "trigger" instance
+    hook:       the defining Hook object (useful for removing)
+    """
+    response = requests.post(
+        url=target,
+        data=json.dumps(payload, cls=DjangoJSONEncoder),
+        headers={'Content-Type': 'application/json'}
+    )
 
-class DeliverHook(Task):
-    def run(self, target, payload, instance=None, hook_id=None, **kwargs):
-        """
-        target:     the url to receive the payload.
-        payload:    a python primitive data structure
-        instance:   a possibly null "trigger" instance
-        hook:       the defining Hook object (useful for removing)
-        """
-        response = requests.post(
-            url=target,
-            data=json.dumps(payload, cls=DjangoJSONEncoder),
-            headers={'Content-Type': 'application/json'}
-        )
+    if response.status_code == 410 and hook_id:
+        HookModel = get_hook_model()
+        hook = HookModel.object.get(id=hook_id)
+        hook.delete()
 
-        if response.status_code == 410 and hook_id:
-            HookModel = get_hook_model()
-            hook = HookModel.object.get(id=hook_id)
-            hook.delete()
+    # would be nice to log this, at least for a little while...
 
-        # would be nice to log this, at least for a little while...
+
+try:
+    # Celery < 5.0 backwards compatibility
+    from celery.task import Task
+    class DeliverHook(Task):
+        def run(self, target, payload, instance=None, hook_id=None, **kwargs):
+            _do_hook(target, payload, instance=None, hook_id=None, **kwargs)
+except ImportError:
+    from celery import shared_task
+
+    @shared_task
+    class DeliverHook:
+        def __init__():
+            pass
+
+        def __call__(self, target, payload, instance=None, hook_id=None, **kwargs):
+            _do_hook(target, payload, instance=None, hook_id=None, **kwargs)
+
+
 
 def deliver_hook_wrapper(target, payload, instance=None, hook=None, **kwargs):
     if hook:


### PR DESCRIPTION
`django-rest-hooks` will cause our celery pods to fail on startup.  If we fix the imports so they're Celery 5 compatible, maybe the pods will start and we can start working on real testing.